### PR TITLE
Fix CD and build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,4 @@ jobs:
         # GCP authorization credentials
         APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
       with:
-        args: compute ssh lendbot@instance-1 --zone=us-central1-c --command='cd /home/lendbot/lendbot && git pull && ./launch'
+        args: compute ssh lendbot@instance-1 --zone=us-central1-c --command='sudo reboot'

--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ lendbot
 1. Activate virtualenv: `source venv/bin/activate` on Unix or `venv/Scripts/activate` on Windows
 
 2. Run the launcher: `./launch`
+
+## Continuous deployment
+GitHub Actions is configured to reboot a Google Cloud instance `instance-1`,
+on zone `us-centra1-c` on project `lendbot` on a push to `master`.
+
+The default instance is configured with the following `startup-script`:
+```bash
+#!/bin/bash
+cd /home/lendbot/lendbot
+suod -S -u lendbot git pull
+sudo -S -u lendbot ./launch
+```

--- a/ext/vac.py
+++ b/ext/vac.py
@@ -115,6 +115,6 @@ def setup(bot: discord.ext.commands.Bot):
     channel = bot.get_channel(int(config.default_channel))
 
     async def job():
-        await vac.check_vac_status_and_send_results(channel, True)
+        await vac.check_vac_status_and_send_results(channel, False)
 
     schedule.every().day.at("12:00").do(job)

--- a/launcher.py
+++ b/launcher.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging.config
 import os
+import traceback
 
 import aioschedule as schedule
 
@@ -8,9 +9,18 @@ import credentials
 from lendbot import Lendbot
 
 
+async def start_scheduler():
+    await asyncio.sleep(10)
+    await run_scheduler()
+
+
 async def run_scheduler():
-    await schedule.run_pending()
-    asyncio.get_event_loop().call_later(1, run_scheduler)
+    try:
+        await schedule.run_pending()
+    except Exception:
+        print(traceback.format_exc())
+    await asyncio.sleep(1)
+    asyncio.get_running_loop().create_task(run_scheduler())
 
 
 log = logging.getLogger()
@@ -29,5 +39,5 @@ log.addHandler(ch)
 
 bot = Lendbot()
 
-asyncio.get_event_loop().call_later(10, run_scheduler)
+asyncio.get_event_loop().create_task(start_scheduler())
 bot.run(credentials.token)


### PR DESCRIPTION
- Update GitHub action to reboot and use newly added startup script on the instance.
- Fix vac to not print "no bans" message when run automatically.
- Fix async scheduler to finally work and stop crashing the app

Launch script configured on instance:
```bash
#!/bin/bash
cd /home/lendbot/lendbot
suod -S -u lendbot git pull
sudo -S -u lendbot ./launch
```