### PR TITLE
Make Github action green

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,4 @@ jobs:
         # GCP authorization credentials
         APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
       with:
-        args: compute ssh lendbot@instance-1 --zone=us-central1-c --command='sudo reboot'
+        args: compute ssh lendbot@instance-1 --zone=us-central1-c --command='sudo shutdown -r'


### PR DESCRIPTION
Deployment works but errors out in Github, delay the reboot so that doesn't happen.